### PR TITLE
Fix - correcting conversion issue on sequence start number when doing…

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1168,7 +1168,12 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         if (currentMetadata == null) {
           metadataUpdateSuccess = true;
         } else {
-          final DataSourceMetadata newMetadata = currentMetadata.minus(resetMetadata);
+          // At this point the desire is to reset the supervisor, so this conversion
+          // to startMetadata is required to prevent the supervisor from becoming unable
+          // to schedule new indexing tasks in the situation where the sequence number
+          // metatdata types are mismatched.
+          final DataSourceMetadata newMetadata = currentMetadata.asStartMetadata()
+              .minus(resetMetadata.asStartMetadata());
           try {
             metadataUpdateSuccess = indexerMetadataStorageCoordinator.resetDataSourceMetadata(dataSource, newMetadata);
           }


### PR DESCRIPTION
… internal reset.

This is very similar to the issue described here: https://github.com/apache/incubator-druid/pull/7332

This only happens when the middle manager is cut off in the middle of an indexing task at a certain time which causes a race condition breaking the metadata type being stored for the datastore. It results in this exception:

"log":"2019-05-29T18:11:59,574 ERROR [KafkaSupervisor-npav-ts-metrics-1h] org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor - SeekableStreamSupervisor[npav-ts-metrics-1h] failed to handle notice: {class=org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor, exceptionType=class org.apache.druid.java.util.common.IAE, exceptionMessage=Expected instance of org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers, got org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers, noticeClass=RunNotice}\n","stream":"stdout","time":"2019-05-29T18:11:59.575001166Z"}
{"log":"org.apache.druid.java.util.common.IAE: Expected instance of org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers, got org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers\n","stream":"stdout","time":"2019-05-29T18:11:59.575037574Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers.minus(SeekableStreamEndSequenceNumbers.java:159) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575080172Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.SeekableStreamDataSourceMetadata.minus(SeekableStreamDataSourceMetadata.java:95) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575086469Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.resetInternal(SeekableStreamSupervisor.java:1147) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575091749Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.getOffsetFromStorageForPartition(SeekableStreamSupervisor.java:2380) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575096907Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.generateStartingSequencesForPartitionGroup(SeekableStreamSupervisor.java:2357) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575102327Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.createNewTasks(SeekableStreamSupervisor.java:2254) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575107513Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.runInternal(SeekableStreamSupervisor.java:1013) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575113493Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor$RunNotice.handle(SeekableStreamSupervisor.java:265) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.57511851Z"}
{"log":"\u0009at org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor.lambda$tryInit$3(SeekableStreamSupervisor.java:724) ~[druid-indexing-service-0.14.0-incubating.jar:0.14.0-incubating]\n","stream":"stdout","time":"2019-05-29T18:11:59.575123307Z"}
{"log":"\u0009at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_66-internal]\n","stream":"stdout","time":"2019-05-29T18:11:59.575127713Z"}
{"log":"\u0009at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_66-internal]\n","stream":"stdout","time":"2019-05-29T18:11:59.575187003Z"}
{"log":"\u0009at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_66-internal]\n","stream":"stdout","time":"2019-05-29T18:11:59.575193321Z"}
{"log":"\u0009at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_66-internal]\n","stream":"stdout","time":"2019-05-29T18:11:59.575197266Z"}
{"log":"\u0009at java.lang.Thread.run(Thread.java:745) [?:1.8.0_66-internal]\n","stream":"stdout","time":"2019-05-29T18:11:59.575201222Z"}